### PR TITLE
[codex] Harden review fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,17 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Lint backend
+        run: cargo clippy --all-targets -- -D warnings
+
       - name: Test backend
         run: cargo test --verbose
 
       - name: Build backend release
         run: cargo build --release --verbose
+
+      - name: Lint Web UI crate
+        run: cargo clippy --manifest-path webui/Cargo.toml --all-targets -- -D warnings
 
       - name: Test Web UI crate
         run: cargo test --manifest-path webui/Cargo.toml --verbose

--- a/benches/scanner_bench.rs
+++ b/benches/scanner_bench.rs
@@ -1,9 +1,10 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use speicherwald::db;
 use speicherwald::scanner::run_scan;
 use speicherwald::types::ScanOptions;
 use sqlx::sqlite::SqlitePoolOptions;
 use std::fs;
+use std::hint::black_box;
 use std::path::Path;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -37,13 +37,10 @@ use tauri::{Manager, WindowUrl};
 
 /// Application state for managing the backend process.
 ///
-/// Holds a mutex-protected reference to the spawned backend child process
-/// and the port number on which the backend is running.
+/// Holds a mutex-protected reference to the spawned backend child process.
 struct BackendState {
   /// The spawned backend process handle
   child: Mutex<Option<Child>>,
-  /// The port number the backend is running on
-  port: u16,
 }
 
 /// Finds an available TCP port on the localhost interface.
@@ -317,7 +314,7 @@ fn main() {
 
       match child_res {
         Ok(child) => {
-          let state = BackendState { child: Mutex::new(Some(child)), port };
+          let state = BackendState { child: Mutex::new(Some(child)) };
           app.manage(state);
 
           // wait until ready and then open window
@@ -378,7 +375,7 @@ fn main() {
       if let tauri::WindowEvent::CloseRequested { .. } = event.event() {
         if let Some(state) = event.window().try_state::<BackendState>() {
           let mut guard = state.child.lock().unwrap();
-          kill_backend(&mut *guard);
+          kill_backend(&mut guard);
         }
       }
     })

--- a/src/config.rs
+++ b/src/config.rs
@@ -221,7 +221,7 @@ pub fn ensure_sqlite_parent_dir(url: &str) -> anyhow::Result<()> {
                 let drive_byte = bytes[1];
                 // Only allow valid ASCII drive letters (A-Z, a-z)
                 // Extended ASCII (>= 128) is NOT valid for Windows drive letters
-                if (drive_byte >= b'A' && drive_byte <= b'Z') || (drive_byte >= b'a' && drive_byte <= b'z') {
+                if drive_byte.is_ascii_alphabetic() {
                     &path[1..]
                 } else {
                     // Invalid drive letter, keep the path as-is and let it fail naturally

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,3 @@
-// FIX Bug #19: Removed dead_code annotation - address dead code properly
-
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -14,6 +12,7 @@ use std::fmt;
 /// This enum consolidates all possible errors that can occur within the application,
 /// providing a unified way to handle and respond to failures.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum AppError {
     /// For internal server errors that are not expected to be handled by the client.
     Internal(anyhow::Error),
@@ -194,6 +193,7 @@ pub type AppResult<T> = Result<T, AppError>;
 
 /// An extension trait for `Option` that provides a convenient way to convert
 /// an `Option` to a `Result` with a `NotFound` error.
+#[allow(dead_code)]
 pub trait OptionExt<T> {
     /// Converts an `Option<T>` to a `Result<T, AppError>`.
     ///
@@ -215,6 +215,7 @@ impl<T> OptionExt<T> for Option<T> {
 }
 
 /// A module containing helper functions for request validation.
+#[allow(dead_code)]
 pub mod validation {
     use super::*;
     use std::path::Path;

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,9 +170,9 @@ async fn main() -> anyhow::Result<()> {
     let state_with_limits = {
         let mut s = state.clone();
         s.rate_limiter = s.rate_limiter.with_limits(vec![
-            ("/scans", 30, 60),           // 30 requests per minute for scan creation
-            ("/paths/move", 10, 60),      // 10 move operations per minute
-            // Removed: ("/scans/{id}/events", ...) - doesn't work with parametrized routes
+            ("/scans", 30, 60), // 30 requests per minute for scan creation
+            ("/paths/move", 10, 60), // 10 move operations per minute
+                                // Removed: ("/scans/{id}/events", ...) - doesn't work with parametrized routes
         ]);
         s
     };

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -14,9 +14,8 @@ pub async fn auth_middleware(req: Request, next: Next) -> Result<Response, Statu
     // Check if auth is enabled via env var
     // FIX Bug #6: Cache the token lookup to avoid env var overhead on every request
     static AUTH_TOKEN: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
-    let expected_token_opt = AUTH_TOKEN.get_or_init(|| {
-        std::env::var("SPEICHERWALD_AUTH_TOKEN").ok().filter(|t| !t.is_empty())
-    });
+    let expected_token_opt =
+        AUTH_TOKEN.get_or_init(|| std::env::var("SPEICHERWALD_AUTH_TOKEN").ok().filter(|t| !t.is_empty()));
 
     let expected_token = match expected_token_opt {
         Some(t) => t,
@@ -24,10 +23,7 @@ pub async fn auth_middleware(req: Request, next: Next) -> Result<Response, Statu
     };
 
     // Check header
-    let auth_header = req
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|h| h.to_str().ok());
+    let auth_header = req.headers().get(header::AUTHORIZATION).and_then(|h| h.to_str().ok());
 
     match auth_header {
         Some(auth_val) if auth_val.starts_with("Bearer ") => {

--- a/src/middleware/csrf.rs
+++ b/src/middleware/csrf.rs
@@ -4,6 +4,8 @@
 //! unauthorized requests from malicious websites. The current implementation uses a
 //! simple static token approach suitable for trusted web UI clients.
 
+#![allow(dead_code)]
+
 use axum::{
     extract::Request,
     http::{HeaderMap, Method, StatusCode},
@@ -17,42 +19,42 @@ const CSRF_HEADER: &str = "X-CSRF-Token";
 const CSRF_EXPECTED_VALUE: &str = "speicherwald-api-request";
 
 /// CSRF protection middleware for state-changing operations.
-/// 
+///
 /// This middleware validates CSRF tokens for HTTP methods that modify state
 /// (POST, PUT, DELETE, PATCH) to prevent Cross-Site Request Forgery attacks.
-/// 
+///
 /// # Security Note
-/// 
+///
 /// This is a simplified CSRF protection suitable for APIs accessed by
 /// a trusted web UI. For production use with untrusted clients, consider:
 /// - Generating unique tokens per session
 /// - Token expiration and rotation
 /// - Cryptographic token validation
 /// - SameSite cookie attributes
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `req` - The incoming HTTP request
 /// * `next` - The next middleware in the chain
-/// 
+///
 /// # Returns
-/// 
+///
 /// A response that either continues the request chain or returns a 403 Forbidden
 /// status with error details if CSRF validation fails.
 pub async fn csrf_protection_middleware(req: Request, next: Next) -> Response {
     let method = req.method();
-    
+
     // Only check CSRF for state-changing methods
     if matches!(method, &Method::POST | &Method::PUT | &Method::DELETE | &Method::PATCH) {
         let headers = req.headers();
-        
+
         if !validate_csrf_token(headers) {
             return (
                 StatusCode::FORBIDDEN,
                 Json(json!({
                     "error": {
                         "code": "CSRF_TOKEN_MISSING",
-                        "message": format!("CSRF token required. Include '{}' header with value '{}'", 
+                        "message": format!("CSRF token required. Include '{}' header with value '{}'",
                             CSRF_HEADER, CSRF_EXPECTED_VALUE),
                     },
                     "status": 403,
@@ -61,25 +63,21 @@ pub async fn csrf_protection_middleware(req: Request, next: Next) -> Response {
                 .into_response();
         }
     }
-    
+
     next.run(req).await
 }
 
 /// Validates the CSRF token in the request headers.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `headers` - The HTTP request headers to validate
-/// 
+///
 /// # Returns
-/// 
+///
 /// `true` if the CSRF token is present and valid, `false` otherwise.
 fn validate_csrf_token(headers: &HeaderMap) -> bool {
-    headers
-        .get(CSRF_HEADER)
-        .and_then(|v| v.to_str().ok())
-        .map(|v| v == CSRF_EXPECTED_VALUE)
-        .unwrap_or(false)
+    headers.get(CSRF_HEADER).and_then(|v| v.to_str().ok()).map(|v| v == CSRF_EXPECTED_VALUE).unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -92,10 +90,10 @@ mod tests {
     fn test_csrf_validation() {
         let mut headers = HeaderMap::new();
         assert!(!validate_csrf_token(&headers));
-        
+
         headers.insert(CSRF_HEADER, HeaderValue::from_static(CSRF_EXPECTED_VALUE));
         assert!(validate_csrf_token(&headers));
-        
+
         headers.insert(CSRF_HEADER, HeaderValue::from_static("wrong-value"));
         assert!(!validate_csrf_token(&headers));
     }

--- a/src/middleware/ip.rs
+++ b/src/middleware/ip.rs
@@ -58,7 +58,7 @@ pub fn extract_ip_from_headers(headers: &HeaderMap, fallback: Option<IpAddr>) ->
     // in a single reverse-proxy setup than the leftmost (which can be spoofed by the client).
     // Note: In complex multi-proxy chains, this requires the last proxy to be trusted.
     if let Some(h) = headers.get("x-forwarded-for").and_then(|hv| hv.to_str().ok()) {
-        if let Some(last) = h.split(',').last() {
+        if let Some(last) = h.split(',').next_back() {
             if let Ok(ip) = last.trim().parse::<IpAddr>() {
                 return ip;
             }
@@ -119,15 +119,10 @@ where
     ///
     /// `Ok(Self)` containing `Some(SocketAddr)` if extraction succeeds,
     /// or `None` if connection information is not available
-    fn from_request_parts(
-        parts: &mut Parts,
-        state: &S,
-    ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send {
-        async move {
-            match ConnectInfo::<SocketAddr>::from_request_parts(parts, state).await {
-                Ok(ConnectInfo(addr)) => Ok(MaybeRemoteAddr(Some(addr))),
-                Err(_) => Ok(MaybeRemoteAddr(None)),
-            }
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match ConnectInfo::<SocketAddr>::from_request_parts(parts, state).await {
+            Ok(ConnectInfo(addr)) => Ok(MaybeRemoteAddr(Some(addr))),
+            Err(_) => Ok(MaybeRemoteAddr(None)),
         }
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -6,10 +6,10 @@
 //! comprehensive request processing pipeline.
 
 pub mod auth;
+pub mod csrf;
 pub mod ip;
 pub mod rate_limit;
 pub mod security_headers;
-pub mod validation;
-pub mod csrf; // FIX Bug #30: CSRF protection
+pub mod validation; // FIX Bug #30: CSRF protection
 
 pub use rate_limit::EndpointRateLimiter;

--- a/src/middleware/rate_limit.rs
+++ b/src/middleware/rate_limit.rs
@@ -250,20 +250,15 @@ impl EndpointRateLimiter {
         // Extract existing limiters or create new HashMap
         let mut limiters_map = match Arc::try_unwrap(self.limiters) {
             Ok(rwlock) => rwlock.into_inner(),
-            Err(arc) => arc
-                .try_read()
-                .map(|guard| guard.clone())
-                .unwrap_or_else(|_| HashMap::new()),
+            Err(arc) => arc.try_read().map(|guard| guard.clone()).unwrap_or_else(|_| HashMap::new()),
         };
-        
+
         // Add/update new limits
         for (endpoint, max_requests, window_seconds) in limits {
             limiters_map.insert(endpoint.to_string(), RateLimiter::new(max_requests, window_seconds));
         }
-        
-        Self {
-            limiters: Arc::new(RwLock::new(limiters_map))
-        }
+
+        Self { limiters: Arc::new(RwLock::new(limiters_map)) }
     }
 
     /// Checks if a request to a specific endpoint from a given IP address is allowed.
@@ -317,6 +312,7 @@ impl EndpointRateLimiter {
 /// # Arguments
 ///
 /// * `limiter` - The `RateLimiter` to clean up
+#[allow(dead_code)]
 pub async fn cleanup_task(limiter: RateLimiter) {
     let mut interval = tokio::time::interval(Duration::from_secs(300)); // Clean every 5 minutes
 

--- a/src/middleware/security_headers.rs
+++ b/src/middleware/security_headers.rs
@@ -105,10 +105,13 @@ pub async fn security_headers_middleware(
     // Defensive caching policy for API responses (JSON) and SSE streams only
     // FIX Bug #38: Better handling of invalid UTF-8 in Content-Type
     let ct_val: Option<String> = headers.get(CONTENT_TYPE).and_then(|ct| {
-        ct.to_str().map_err(|e| {
-            tracing::warn!("Invalid UTF-8 in Content-Type header: {}", e);
-            e
-        }).ok().map(|s| s.to_string())
+        ct.to_str()
+            .map_err(|e| {
+                tracing::warn!("Invalid UTF-8 in Content-Type header: {}", e);
+                e
+            })
+            .ok()
+            .map(|s| s.to_string())
     });
     if let Some(s) = ct_val.as_deref() {
         let is_json = s.starts_with("application/json");

--- a/src/middleware/validation.rs
+++ b/src/middleware/validation.rs
@@ -290,7 +290,7 @@ pub fn validate_file_path(path: &str) -> Result<String, (StatusCode, Json<serde_
         if !is_extended {
             for c in INVALID_CHARS {
                 if path.contains(*c) {
-                     return Err((
+                    return Err((
                         StatusCode::BAD_REQUEST,
                         Json(json!({
                             "error": {

--- a/src/routes/drives.rs
+++ b/src/routes/drives.rs
@@ -20,7 +20,10 @@ use axum::{
 use serde::Serialize;
 
 use crate::state::AppState;
-use crate::{middleware::ip::{extract_ip_from_headers, MaybeRemoteAddr}, types::DriveInfo};
+use crate::{
+    middleware::ip::{extract_ip_from_headers, MaybeRemoteAddr},
+    types::DriveInfo,
+};
 
 /// Response structure for the drives listing endpoint.
 ///
@@ -73,17 +76,27 @@ pub async fn list_drives(
                 return candidates;
             }
             for i in 0..26u32 {
-                if (mask & (1u32 << i)) == 0 { continue; }
+                if (mask & (1u32 << i)) == 0 {
+                    continue;
+                }
                 let letter = (b'A' + (i as u8)) as char;
                 let path = format!("{}:\\", letter);
                 let w: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
 
                 let dtype = GetDriveTypeW(PCWSTR(w.as_ptr()));
-                if dtype == 0 || dtype == 1 { continue; }
-                
+                if dtype == 0 || dtype == 1 {
+                    continue;
+                }
+
                 let type_str = match dtype {
-                    0 => "unknown", 1 => "invalid", 2 => "removable", 3 => "fixed",
-                    4 => "network", 5 => "cdrom", 6 => "ramdisk", _ => "other",
+                    0 => "unknown",
+                    1 => "invalid",
+                    2 => "removable",
+                    3 => "fixed",
+                    4 => "network",
+                    5 => "cdrom",
+                    6 => "ramdisk",
+                    _ => "other",
                 };
                 candidates.push((path, type_str.to_string(), dtype == 4)); // dtype 4 is network
             }
@@ -103,7 +116,7 @@ pub async fn list_drives(
     // Global semaphore to prevent thread exhaustion across multiple requests
     static DRIVE_CHECK_LIMIT: std::sync::OnceLock<tokio::sync::Semaphore> = std::sync::OnceLock::new();
     let sem = DRIVE_CHECK_LIMIT.get_or_init(|| tokio::sync::Semaphore::new(32));
-    
+
     let items = stream::iter(drive_candidates)
         .map(|(path, drive_type, is_network)| async move {
             let _permit = sem.acquire().await; // Global limit
@@ -111,44 +124,40 @@ pub async fn list_drives(
             let space_info = if is_network {
                 // Network drive: with timeout
                 let timeout_ms = std::env::var("SPEICHERWALD_NETWORK_DRIVE_TIMEOUT_MS")
-                    .ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(1000).clamp(100, 5000);
-                
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(1000)
+                    .clamp(100, 5000);
+
                 let result = tokio::time::timeout(
                     Duration::from_millis(timeout_ms),
-                    tokio::task::spawn_blocking(move || {
-                        get_drive_space(&path_clone)
-                    })
-                ).await;
+                    tokio::task::spawn_blocking(move || get_drive_space(&path_clone)),
+                )
+                .await;
 
                 match result {
                     Ok(Ok(info)) => info, // Success
-                    Ok(Err(e)) => { // Panic in task
+                    Ok(Err(e)) => {
+                        // Panic in task
                         tracing::error!("Drive space task panicked: {}", e);
                         (0, 0, 0)
-                    },
-                    Err(_) => { // Timeout
-                        // tracing::warn!("Timeout getting space for {}", path); 
-                        (0, 0, 0) 
+                    }
+                    Err(_) => {
+                        // Timeout
+                        // tracing::warn!("Timeout getting space for {}", path);
+                        (0, 0, 0)
                     }
                 }
             } else {
                 // Local drive: plain blocking
-                 tokio::task::spawn_blocking(move || {
-                    get_drive_space(&path_clone)
-                }).await.unwrap_or((0, 0, 0))
+                tokio::task::spawn_blocking(move || get_drive_space(&path_clone)).await.unwrap_or((0, 0, 0))
             };
-            
-            DriveInfo {
-                path,
-                drive_type,
-                total_bytes: space_info.1,
-                free_bytes: space_info.2,
-            }
+
+            DriveInfo { path, drive_type, total_bytes: space_info.1, free_bytes: space_info.2 }
         })
         .buffer_unordered(8) // process at most 8 drives concurrently
         .collect::<Vec<_>>()
         .await;
-
 
     Json(DrivesResponse { items }).into_response()
 }
@@ -163,12 +172,8 @@ fn get_drive_space(path: &str) -> (u64, u64, u64) {
     let mut total: u64 = 0;
     let mut total_free: u64 = 0;
     unsafe {
-        let _ = GetDiskFreeSpaceExW(
-            PCWSTR(w.as_ptr()),
-            Some(&mut free),
-            Some(&mut total),
-            Some(&mut total_free),
-        );
+        let _ =
+            GetDiskFreeSpaceExW(PCWSTR(w.as_ptr()), Some(&mut free), Some(&mut total), Some(&mut total_free));
     }
     (free, total, total_free)
 }

--- a/src/routes/export.rs
+++ b/src/routes/export.rs
@@ -32,7 +32,7 @@ use crate::{
 #[derive(Debug, Deserialize)]
 pub struct ExportQuery {
     /// The export format (e.g., "csv", "json").
-    pub format: String,        // csv or json
+    pub format: String, // csv or json
     /// The scope of the export (e.g., "nodes", "files", "all").
     pub scope: Option<String>, // nodes, files, or all
     /// The maximum number of records to export.
@@ -188,29 +188,36 @@ pub async fn export_scan(
 async fn export_csv(state: AppState, scan_id: Uuid, scope: &str, limit: i64) -> AppResult<impl IntoResponse> {
     use axum::body::Body;
     use axum::http::HeaderValue;
-    use futures::stream::TryStreamExt;
 
     let include_nodes = scope == "all" || scope == "nodes";
     let include_files = scope == "all" || scope == "files";
-    let scope_str = scope.to_string();
 
     // Initial state: (last_node_cursor, last_file_cursor, nodes_done, files_done, header_sent, exported_count)
     let initial_state = (None::<String>, None::<(i64, String)>, false, false, false, 0i64);
 
     let stream = futures::stream::try_unfold(
         initial_state,
-        move |(mut last_node_cursor, mut last_file_cursor, mut nodes_done, mut files_done, mut header_sent, mut count)| {
+        move |(
+            mut last_node_cursor,
+            mut last_file_cursor,
+            mut nodes_done,
+            mut files_done,
+            mut header_sent,
+            mut count,
+        )| {
             let state = state.clone();
-            let scope = scope_str.clone();
             async move {
                 if nodes_done && files_done {
                     // Type annotation needed for the compiler
-                    return Ok::<Option<(String, (Option<String>, Option<(i64, String)>, bool, bool, bool, i64))>, AppError>(None);
+                    return Ok::<
+                        Option<(String, (Option<String>, Option<(i64, String)>, bool, bool, bool, i64))>,
+                        AppError,
+                    >(None);
                 }
-                
+
                 let remaining = limit - count;
                 if remaining <= 0 {
-                    return Ok(None); 
+                    return Ok(None);
                 }
 
                 let mut chunk = String::new();
@@ -221,17 +228,19 @@ async fn export_csv(state: AppState, scan_id: Uuid, scope: &str, limit: i64) -> 
                 }
 
                 let batch_size = EXPORT_CHUNK_SIZE.min(remaining);
-                
+
                 // 2. Fetch Nodes
                 if include_nodes && !nodes_done {
                     if count == 0 {
                         chunk.push_str("Type,Path,Parent Path,Depth,Is Directory,Logical Size,Allocated Size,File Count,Dir Count\n");
                     }
-                    
+
                     if batch_size <= 0 {
                         nodes_done = true;
                     } else {
-                        let nodes = fetch_nodes_batch(&state, scan_id, batch_size, last_node_cursor.clone()).await.map_err(AppError::from)?;
+                        let nodes = fetch_nodes_batch(&state, scan_id, batch_size, last_node_cursor.clone())
+                            .await
+                            .map_err(AppError::from)?;
                         if nodes.is_empty() {
                             nodes_done = true;
                         } else {
@@ -244,50 +253,55 @@ async fn export_csv(state: AppState, scan_id: Uuid, scope: &str, limit: i64) -> 
                             count += nodes.len() as i64;
                         }
                     }
-                    
+
                     if nodes_done {
-                        last_node_cursor = None; 
+                        last_node_cursor = None;
                         if include_files {
                             chunk.push('\n');
                         }
                     }
-                } 
+                }
                 // 3. Fetch Files
                 else if include_files && !files_done {
-                     if last_file_cursor.is_none() { 
-                         chunk.push_str("Type,Path,Parent Path,Logical Size,Allocated Size\n");
-                     }
- 
-                     let remaining = limit - count;
-                     let batch_size = EXPORT_CHUNK_SIZE.min(remaining);
+                    if last_file_cursor.is_none() {
+                        chunk.push_str("Type,Path,Parent Path,Logical Size,Allocated Size\n");
+                    }
 
-                     if batch_size <= 0 {
-                         files_done = true;
-                     } else {
-                         let files = fetch_files_batch(&state, scan_id, batch_size, last_file_cursor.clone()).await.map_err(AppError::from)?;
-                         if files.is_empty() {
-                             files_done = true;
-                         } else {
-                             for file in &files {
-                                 chunk.push_str(&format!(
-                                     "File,\"{}\",\"{}\",{},{}\n",
-                                     escape_csv(&file.path),
-                                     escape_csv(file.parent_path.as_deref().unwrap_or("")),
-                                     file.logical_size,
-                                     file.allocated_size,
-                                 ));
-                             }
-                             if let Some(last) = files.last() {
-                                 last_file_cursor = Some((last.allocated_size, last.path.clone()));
-                             }
-                             count += files.len() as i64;
-                         }
-                     }
+                    let remaining = limit - count;
+                    let batch_size = EXPORT_CHUNK_SIZE.min(remaining);
+
+                    if batch_size <= 0 {
+                        files_done = true;
+                    } else {
+                        let files = fetch_files_batch(&state, scan_id, batch_size, last_file_cursor.clone())
+                            .await
+                            .map_err(AppError::from)?;
+                        if files.is_empty() {
+                            files_done = true;
+                        } else {
+                            for file in &files {
+                                chunk.push_str(&format!(
+                                    "File,\"{}\",\"{}\",{},{}\n",
+                                    escape_csv(&file.path),
+                                    escape_csv(file.parent_path.as_deref().unwrap_or("")),
+                                    file.logical_size,
+                                    file.allocated_size,
+                                ));
+                            }
+                            if let Some(last) = files.last() {
+                                last_file_cursor = Some((last.allocated_size, last.path.clone()));
+                            }
+                            count += files.len() as i64;
+                        }
+                    }
                 } else {
                     return Ok(None);
                 }
-                
-                Ok(Some((chunk, (last_node_cursor, last_file_cursor, nodes_done, files_done, header_sent, count))))
+
+                Ok(Some((
+                    chunk,
+                    (last_node_cursor, last_file_cursor, nodes_done, files_done, header_sent, count),
+                )))
             }
         },
     );
@@ -373,7 +387,10 @@ fn escape_csv(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 10);
     for c in s.chars() {
         match c {
-            '"' => { out.push('"'); out.push('"'); },
+            '"' => {
+                out.push('"');
+                out.push('"');
+            }
             '\n' | '\r' => out.push(' '),
             c if c.is_control() => out.push(' '),
             c => out.push(c),
@@ -391,19 +408,27 @@ const EXPORT_CHUNK_SIZE: i64 = 800;
 // Modified for streaming: just fetch one batch at the specific offset and return it.
 // The caller (stream) manages the offset loop.
 /// Fetches all nodes for JSON export (or non-streaming).
-async fn fetch_nodes_all(state: &AppState, scan_id: Uuid, limit: i64) -> Result<Vec<NodeExport>, sqlx::Error> {
+async fn fetch_nodes_all(
+    state: &AppState,
+    scan_id: Uuid,
+    limit: i64,
+) -> Result<Vec<NodeExport>, sqlx::Error> {
     let mut results = Vec::new();
     let mut current_cursor: Option<String> = None;
     let mut count = 0;
     loop {
         let remaining = limit - count;
-        if remaining <= 0 { break; }
+        if remaining <= 0 {
+            break;
+        }
         let batch_size = EXPORT_CHUNK_SIZE.min(remaining);
-        
+
         let batch = fetch_nodes_batch(state, scan_id, batch_size, current_cursor.clone()).await?;
 
-        if batch.is_empty() { break; }
-        
+        if batch.is_empty() {
+            break;
+        }
+
         if let Some(last) = batch.last() {
             current_cursor = Some(last.path.clone());
         }
@@ -416,10 +441,10 @@ async fn fetch_nodes_all(state: &AppState, scan_id: Uuid, limit: i64) -> Result<
 
 /// Fetches a single batch of nodes for export.
 async fn fetch_nodes_batch(
-    state: &AppState, 
-    scan_id: Uuid, 
-    limit: i64, 
-    cursor_path: Option<String>
+    state: &AppState,
+    scan_id: Uuid,
+    limit: i64,
+    cursor_path: Option<String>,
 ) -> Result<Vec<NodeExport>, sqlx::Error> {
     let sid = scan_id.to_string();
     let query_str = if cursor_path.is_some() {
@@ -431,18 +456,12 @@ async fn fetch_nodes_batch(
     };
 
     let query = if let Some(path) = cursor_path.as_ref() {
-         sqlx::query(query_str)
-             .bind(&sid)
-             .bind(path)
-             .bind(limit)
+        sqlx::query(query_str).bind(&sid).bind(path).bind(limit)
     } else {
-         sqlx::query(query_str)
-             .bind(&sid)
-             .bind(limit)
+        sqlx::query(query_str).bind(&sid).bind(limit)
     };
-    
-    let rows = query.fetch_all(&state.db).await?;
 
+    let rows = query.fetch_all(&state.db).await?;
 
     let mut results = Vec::with_capacity(rows.len());
     for row in rows {
@@ -461,23 +480,31 @@ async fn fetch_nodes_batch(
 }
 
 /// Fetches all files for JSON export (or non-streaming).
-async fn fetch_files_all(state: &AppState, scan_id: Uuid, limit: i64) -> Result<Vec<FileExport>, sqlx::Error> {
+async fn fetch_files_all(
+    state: &AppState,
+    scan_id: Uuid,
+    limit: i64,
+) -> Result<Vec<FileExport>, sqlx::Error> {
     let mut results = Vec::new();
     let mut current_cursor: Option<(i64, String)> = None;
     let mut count = 0;
     loop {
         let remaining = limit - count;
-        if remaining <= 0 { break; }
+        if remaining <= 0 {
+            break;
+        }
         let batch_size = EXPORT_CHUNK_SIZE.min(remaining);
-        
+
         let batch = fetch_files_batch(state, scan_id, batch_size, current_cursor.clone()).await?;
 
-        if batch.is_empty() { break; }
-        
+        if batch.is_empty() {
+            break;
+        }
+
         if let Some(last) = batch.last() {
             current_cursor = Some((last.allocated_size, last.path.clone()));
         }
-        
+
         count += batch.len() as i64;
         results.extend(batch);
     }
@@ -486,16 +513,16 @@ async fn fetch_files_all(state: &AppState, scan_id: Uuid, limit: i64) -> Result<
 
 /// Fetches a single batch of files for export.
 async fn fetch_files_batch(
-    state: &AppState, 
-    scan_id: Uuid, 
-    limit: i64, 
-    cursor: Option<(i64, String)>
+    state: &AppState,
+    scan_id: Uuid,
+    limit: i64,
+    cursor: Option<(i64, String)>,
 ) -> Result<Vec<FileExport>, sqlx::Error> {
     let sid = scan_id.to_string();
     // Keyset: (allocated_size, path) < (last_alloc, last_path)
     // DESC order for allocated_size, ASC for path (determinism)
-    // WHERE allocated_size < ? OR (allocated_size = ? AND path > ?) 
-    
+    // WHERE allocated_size < ? OR (allocated_size = ? AND path > ?)
+
     let query_str = if cursor.is_some() {
         "SELECT path, parent_path, logical_size, allocated_size \
          FROM files WHERE scan_id = ?1 AND (allocated_size < ?2 OR (allocated_size = ?3 AND path > ?4)) \
@@ -506,20 +533,12 @@ async fn fetch_files_batch(
     };
 
     let query = if let Some((last_alloc, last_path)) = cursor {
-         sqlx::query(query_str)
-             .bind(&sid)
-             .bind(last_alloc)
-             .bind(last_alloc)
-             .bind(last_path)
-             .bind(limit)
+        sqlx::query(query_str).bind(&sid).bind(last_alloc).bind(last_alloc).bind(last_path).bind(limit)
     } else {
-         sqlx::query(query_str)
-             .bind(&sid)
-             .bind(limit)
+        sqlx::query(query_str).bind(&sid).bind(limit)
     };
-    
-    let rows = query.fetch_all(&state.db).await?;
 
+    let rows = query.fetch_all(&state.db).await?;
 
     let mut results = Vec::with_capacity(rows.len());
     for row in rows {

--- a/src/routes/paths.rs
+++ b/src/routes/paths.rs
@@ -39,19 +39,18 @@ use chrono::Utc;
 use tokio::task::spawn_blocking;
 use walkdir::WalkDir;
 
+#[cfg(windows)]
+use crate::routes::paths_helpers::get_volume_root;
 use crate::{
     error::{AppError, AppResult},
     middleware::{
         ip::{extract_ip_from_headers, MaybeRemoteAddr},
-        validation::{sanitize_for_logging, validate_file_path},
+        validation::validate_file_path,
     },
-    routes::paths_helpers::get_volume_root,
     state::AppState,
-
     types::{MovePathRequest, MovePathResponse},
 };
 use tokio_util::sync::CancellationToken;
-
 
 /// Result of a move/copy operation.
 ///
@@ -110,7 +109,7 @@ pub async fn move_path(
     for (i, src) in req.sources.iter().enumerate() {
         let src_trimmed = src.trim();
         let dest_trimmed = req.destinations[i].trim();
-        
+
         if src_trimmed.is_empty() {
             return Err(AppError::BadRequest("source path must not be empty".into()));
         }
@@ -153,7 +152,7 @@ pub async fn move_path(
     // FIX Bug #6: Add cancellation token for detached task cleanup
     let cancel_token = CancellationToken::new();
     let cancel_child = cancel_token.clone();
-    
+
     let outcome = tokio::select! {
         res = spawn_blocking(move || perform_moves(job_req, cancel_child)) => {
             res.map_err(|e| AppError::Internal(anyhow!("move task join error: {}", e)))?
@@ -195,7 +194,7 @@ fn perform_moves(req: MovePathRequest, cancel: CancellationToken) -> AppResult<M
 
         let source_str = &req.sources[i];
         let dest_str = &req.destinations[i];
-        
+
         // Use a dummy req for each operation to pass the overwrite and remove_source flags down
         let item_req = MovePathRequest {
             sources: vec![source_str.clone()],
@@ -203,14 +202,14 @@ fn perform_moves(req: MovePathRequest, cancel: CancellationToken) -> AppResult<M
             remove_source: req.remove_source,
             overwrite: req.overwrite,
         };
-        
+
         match perform_single_move(&item_req, &cancel) {
             Ok(outcome) => {
                 total_bytes_to_transfer += outcome.bytes_to_transfer;
                 total_bytes_moved += outcome.bytes_moved;
                 total_freed_bytes += outcome.freed_bytes;
                 all_warnings.extend(outcome.warnings);
-            },
+            }
             Err(e) => {
                 all_warnings.push(format!("Failed to move {}: {}", source_str, e));
                 // Continue with the next item instead of failing the whole batch
@@ -218,7 +217,12 @@ fn perform_moves(req: MovePathRequest, cancel: CancellationToken) -> AppResult<M
         }
     }
 
-    Ok(MoveOutcome { bytes_to_transfer: total_bytes_to_transfer, bytes_moved: total_bytes_moved, freed_bytes: total_freed_bytes, warnings: all_warnings })
+    Ok(MoveOutcome {
+        bytes_to_transfer: total_bytes_to_transfer,
+        bytes_moved: total_bytes_moved,
+        freed_bytes: total_freed_bytes,
+        warnings: all_warnings,
+    })
 }
 
 fn perform_single_move(req: &MovePathRequest, cancel: &CancellationToken) -> AppResult<MoveOutcome> {
@@ -246,68 +250,67 @@ fn perform_single_move(req: &MovePathRequest, cancel: &CancellationToken) -> App
     let bytes_to_transfer =
         if metadata.is_dir() { compute_directory_size(&source_path, &mut warnings)? } else { metadata.len() };
 
-    // FIX Bug #34: Check available disk space before proceeding
     if !req.remove_source {
-        // For copy operations, check if destination has enough space
         if let Some(parent) = dest_path.parent() {
-            #[cfg(windows)]
-            {
-                use std::os::windows::ffi::OsStrExt;
-                use windows::core::PCWSTR;
-                use windows::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
-                
-                let root_path = get_volume_root(parent);
-                let w: Vec<u16> = std::ffi::OsStr::new(&root_path)
-                    .encode_wide()
-                    .chain(std::iter::once(0))
-                    .collect();
-                
-                unsafe {
-                    let mut free_bytes_available = 0u64;
-                    if GetDiskFreeSpaceExW(
-                        PCWSTR(w.as_ptr()),
-                        Some(&mut free_bytes_available),
-                        None,
-                        None,
-                    ).is_ok() {
-                        // Add 10% buffer for safety
-                        let required = bytes_to_transfer + (bytes_to_transfer / 10);
-                        if free_bytes_available < required {
-                            return Err(AppError::BadRequest(format!(
-                                "Insufficient disk space: {} available, {} required",
-                                free_bytes_available, required
-                            )));
-                        }
-                    }
-                }
-            }
-            #[cfg(unix)]
-            {
-                // Unix disk space check could be added here using statvfs
-                tracing::debug!("Disk space check not implemented on Unix");
-            }
+            ensure_destination_space(parent, bytes_to_transfer)?;
         }
     }
 
     let bytes_moved = if metadata.is_file() {
-        move_file(&source_path, &dest_path, req, cancel)?
+        move_file(&source_path, &dest_path, req, &mut warnings, bytes_to_transfer, cancel)?
     } else if metadata.is_dir() {
-        move_directory(&source_path, &dest_path, req, &mut warnings, cancel)?
+        move_directory(&source_path, &dest_path, req, &mut warnings, bytes_to_transfer, cancel)?
     } else {
         return Err(AppError::BadRequest("source must refer to a file or directory".into()));
     };
 
     // FIX Bug #8: Correctly calculate freed bytes.
-    let freed_bytes = if req.remove_source && !source_path.exists() { 
-        bytes_to_transfer 
-    } else { 
-        0 
-    };
+    let freed_bytes = if req.remove_source && !source_path.exists() { bytes_to_transfer } else { 0 };
 
     Ok(MoveOutcome { bytes_to_transfer, bytes_moved, freed_bytes, warnings })
 }
 
-fn move_file(source: &Path, destination: &Path, req: &MovePathRequest, cancel: &CancellationToken) -> AppResult<u64> {
+fn ensure_destination_space(parent: &Path, bytes_to_transfer: u64) -> AppResult<()> {
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows::core::PCWSTR;
+        use windows::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+
+        let root_path = get_volume_root(parent);
+        let w: Vec<u16> = std::ffi::OsStr::new(&root_path).encode_wide().chain(std::iter::once(0)).collect();
+
+        unsafe {
+            let mut free_bytes_available = 0u64;
+            if GetDiskFreeSpaceExW(PCWSTR(w.as_ptr()), Some(&mut free_bytes_available), None, None).is_ok() {
+                let required = bytes_to_transfer.saturating_add(bytes_to_transfer / 10);
+                if free_bytes_available < required {
+                    return Err(AppError::BadRequest(format!(
+                        "Insufficient disk space: {} available, {} required",
+                        free_bytes_available, required
+                    )));
+                }
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = (parent, bytes_to_transfer);
+        tracing::debug!("Disk space check not implemented on this platform");
+    }
+
+    Ok(())
+}
+
+fn move_file(
+    source: &Path,
+    destination: &Path,
+    req: &MovePathRequest,
+    warnings: &mut Vec<String>,
+    bytes_to_transfer: u64,
+    cancel: &CancellationToken,
+) -> AppResult<u64> {
     if cancel.is_cancelled() {
         return Err(AppError::Internal(anyhow!("Operation cancelled")));
     }
@@ -351,17 +354,24 @@ fn move_file(source: &Path, destination: &Path, req: &MovePathRequest, cancel: &
                 // fs::copy overwrites by default.
                 // If overwrite=false, we MUST check.
                 if !req.overwrite && destination.exists() {
-                     return Err(AppError::Conflict(format!("destination file already exists: {}", destination.display())));
+                    return Err(AppError::Conflict(format!(
+                        "destination file already exists: {}",
+                        destination.display()
+                    )));
                 }
 
+                if let Some(parent) = destination.parent() {
+                    ensure_destination_space(parent, bytes_to_transfer)?;
+                }
                 let copied = copy_file(source, destination, cancel)?;
-                // FIX Bug #8: Handle partial failure (copy success, delete fail)
                 if let Err(e) = fs::remove_file(source) {
-
-                    tracing::warn!("Failed to remove source file after copy: {} ({})", source.display(), e);
-                    // We return success because the data is safe at destination, but source remains.
-                    // Ideally we should warn the user, but we can't easily propagate warnings from here
-                    // without changing the signature. For now, logging must suffice.
+                    let msg = format!(
+                        "Warning: source file could not be removed after copy fallback: {} ({})",
+                        source.display(),
+                        e
+                    );
+                    tracing::warn!("{}", msg);
+                    warnings.push(msg);
                 }
                 return Ok(copied);
             }
@@ -376,6 +386,7 @@ fn move_directory(
     destination: &Path,
     req: &MovePathRequest,
     warnings: &mut Vec<String>,
+    bytes_to_transfer: u64,
     cancel: &CancellationToken,
 ) -> AppResult<u64> {
     if destination.exists() {
@@ -405,10 +416,17 @@ fn move_directory(
                     source.display(),
                     err.kind()
                 );
-                let bytes = copy_directory(source, destination, req.overwrite, req.remove_source, warnings, cancel)?;
-                // FIX Bug #8: Handle partial failure (copy success, delete fail)
+                if let Some(parent) = destination.parent() {
+                    ensure_destination_space(parent, bytes_to_transfer)?;
+                }
+                let bytes =
+                    copy_directory(source, destination, req.overwrite, req.remove_source, warnings, cancel)?;
                 if let Err(e) = fs::remove_dir_all(source) {
-                    let msg = format!("Warnung: Quellordner konnte nach Verschieben nicht gelöscht werden: {}", e);
+                    let msg = format!(
+                        "Warning: source directory could not be removed after copy fallback: {} ({})",
+                        source.display(),
+                        e
+                    );
                     tracing::warn!("{}", msg);
                     warnings.push(msg);
                 }
@@ -475,9 +493,9 @@ fn copy_directory(
             }
         };
         if cancel.is_cancelled() {
-             // FIX Bug #5: Always rollback partial copies on cancellation to prevent garbage
-             rollback_partial(&created_files, &created_dirs);
-             return Err(AppError::Internal(anyhow!("Operation cancelled")));
+            // FIX Bug #5: Always rollback partial copies on cancellation to prevent garbage
+            rollback_partial(&created_files, &created_dirs);
+            return Err(AppError::Internal(anyhow!("Operation cancelled")));
         }
         let rel = match entry.path().strip_prefix(source) {
             Ok(r) => r,
@@ -517,7 +535,8 @@ fn copy_directory(
             if let Ok(metadata) = entry.metadata() {
                 const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
                 if (metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
-                    warnings.push(format!("Reparse point/junction uebersprungen: {}", entry.path().display()));
+                    warnings
+                        .push(format!("Reparse point/junction uebersprungen: {}", entry.path().display()));
                     continue;
                 }
             }
@@ -548,10 +567,7 @@ fn copy_directory(
                         target.display()
                     )));
                 } else {
-                    warnings.push(format!(
-                        "Ordner bereits vorhanden, uebersprungen: {}",
-                        target.display()
-                    ));
+                    warnings.push(format!("Ordner bereits vorhanden, uebersprungen: {}", target.display()));
                     continue;
                 }
             } else if overwrite {

--- a/src/routes/paths_helpers.rs
+++ b/src/routes/paths_helpers.rs
@@ -5,6 +5,7 @@
 //! These utilities are used throughout the application to ensure consistent
 //! path handling regardless of the underlying platform.
 
+#[cfg(windows)]
 use std::path::Path;
 
 /// Windows-specific function to get the volume root for a given path.
@@ -44,23 +45,4 @@ pub fn get_volume_root(path: &Path) -> String {
 
     // Default to C:
     "C:\\".to_string()
-}
-
-/// Non-Windows fallback function for getting the volume root.
-///
-/// On Unix-like systems (Linux, macOS, etc.), there is a single unified
-/// filesystem hierarchy starting at the root directory `/`. This function
-/// provides a consistent interface across platforms by always returning the
-/// Unix root path.
-///
-/// # Arguments
-///
-/// * `_path` - The path parameter is ignored on non-Windows systems
-///
-/// # Returns
-///
-/// Always returns `"/"` - the Unix root directory
-#[cfg(not(windows))]
-pub fn get_volume_root(_path: &Path) -> String {
-    "/".to_string()
 }

--- a/src/routes/paths_helpers.rs
+++ b/src/routes/paths_helpers.rs
@@ -27,13 +27,13 @@ use std::path::Path;
 #[cfg(windows)]
 pub fn get_volume_root(path: &Path) -> String {
     let path_str = path.to_string_lossy();
-    
+
     // Extract drive letter for regular paths
     if path_str.len() >= 2 && path_str.chars().nth(1) == Some(':') {
         let drive = path_str.chars().next().unwrap_or('C');
         return format!("{}:\\", drive);
     }
-    
+
     // For UNC paths, return the server\share part
     if path_str.starts_with("\\\\") {
         let parts: Vec<&str> = path_str.trim_start_matches("\\\\").split('\\').collect();
@@ -41,7 +41,7 @@ pub fn get_volume_root(path: &Path) -> String {
             return format!("\\\\{}\\{}", parts[0], parts[1]);
         }
     }
-    
+
     // Default to C:
     "C:\\".to_string()
 }

--- a/src/routes/scans.rs
+++ b/src/routes/scans.rs
@@ -33,7 +33,10 @@
 //! - Database operations use transactions for consistency
 //! - Large result sets are paginated to prevent resource exhaustion
 
-use std::{path::{Path as StdPath, PathBuf}, time::Duration};
+use std::{
+    path::{Path as StdPath, PathBuf},
+    time::Duration,
+};
 
 use axum::response::sse::{Event, Sse};
 use axum::{
@@ -210,9 +213,9 @@ pub async fn create_scan(
             Ok(summary) => {
                 // FIX Bug #10: Check cancellation before marking as done
                 if cancel_child.is_cancelled() {
-                   // ... (same as Err(cancelled) block)
-                   let _ = tx_clone.send(ScanEvent::Cancelled);
-                   if let Err(e) = sqlx::query(
+                    // ... (same as Err(cancelled) block)
+                    let _ = tx_clone.send(ScanEvent::Cancelled);
+                    if let Err(e) = sqlx::query(
                         r#"UPDATE scans SET status='canceled', finished_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id=?1"#
                     )
                     .bind(id.to_string())
@@ -413,21 +416,18 @@ pub async fn cancel_scan(
 ) -> AppResult<impl IntoResponse> {
     let purge = q.purge.unwrap_or(false);
 
-    // FIX Bug #12 - Race condition: check status first, then cancel
+    // Keep the job registered until the worker has stopped writing scan data.
     let was_running = {
-        let mut jobs = state.jobs.write().await;
-        if let Some(handle) = jobs.remove(&id) {
+        let jobs = state.jobs.read().await;
+        if let Some(handle) = jobs.get(&id) {
             handle.cancel.cancel();
-            drop(jobs); // Release lock before any async operations
             true
         } else {
             false
         }
     };
 
-    // FIX Bug #27: Use transaction for atomic operation
-    // Update DB after releasing lock to avoid deadlock
-    if was_running && !purge {
+    if was_running {
         if let Err(e) = sqlx::query(
             r#"UPDATE scans SET status='canceled', finished_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id=?1 AND status='running'"#
         )
@@ -435,14 +435,33 @@ pub async fn cancel_scan(
         .execute(&state.db).await {
             tracing::error!("Failed to update scan status to canceled: {}", e);
         }
-    } else if !was_running && !purge {
+    } else if !purge {
         // Not running: act idempotently
         return Ok((StatusCode::NO_CONTENT, ""));
     }
 
     if purge {
-        // Delete scan row (cascade to nodes/files/warnings)
-        let _ = sqlx::query(r#"DELETE FROM scans WHERE id=?1"#).bind(id.to_string()).execute(&state.db).await;
+        if was_running {
+            let db = state.db.clone();
+            let jobs = state.jobs.clone();
+            tokio::spawn(async move {
+                loop {
+                    if !jobs.read().await.contains_key(&id) {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                if let Err(e) =
+                    sqlx::query(r#"DELETE FROM scans WHERE id=?1"#).bind(id.to_string()).execute(&db).await
+                {
+                    tracing::error!("Failed to purge canceled scan {}: {}", id, e);
+                }
+            });
+        } else if let Err(e) =
+            sqlx::query(r#"DELETE FROM scans WHERE id=?1"#).bind(id.to_string()).execute(&state.db).await
+        {
+            tracing::error!("Failed to purge scan {}: {}", id, e);
+        }
     }
 
     Ok((StatusCode::NO_CONTENT, ""))
@@ -461,7 +480,7 @@ pub async fn cancel_scan(
 /// # Returns
 ///
 /// * `AppResult<Sse<impl Stream<Item = Result<Event, std::convert::Infallible>>>>` -
-///  An SSE stream of scan events.
+///   An SSE stream of scan events.
 pub async fn scan_events(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
@@ -500,12 +519,6 @@ pub async fn scan_events(
 }
 
 // Removed - inline usage is clearer and avoids potential timezone issues
-
-
-
-
-
-
 
 const LIKE_ESCAPE: char = '!';
 const TREE_LIMIT_MAX: i64 = 2_000;
@@ -661,7 +674,6 @@ pub async fn get_tree(
         }
         // FIX Bug #8: Escape special characters to prevent SQL injection via path
         let pfx_escaped = escape_like_pattern(&pfx);
-        let pfx_upper = format!("{}~", pfx_escaped);
         // FIX Bug #3 (Unicode Query): Use LIKE instead of range optimization
         // Range optimization (path >= pfx AND path < pfx_upper) is tricky with Unicode.
         // SQLite's LIKE operator is safer and sufficient here given the index.
@@ -797,9 +809,9 @@ pub async fn get_top(
 #[derive(Debug, Default, serde::Deserialize)]
 pub struct ListQuery {
     /// The path of the directory to list. If not provided, the root directories of the scan are listed.
-    pub path: Option<String>,  // if None: list roots only (directories)
+    pub path: Option<String>, // if None: list roots only (directories)
     /// The sort order for the results (e.g., "allocated", "logical", "name", "type").
-    pub sort: Option<String>,  // allocated|logical|name|type
+    pub sort: Option<String>, // allocated|logical|name|type
     /// The sort direction ("asc" or "desc").
     pub order: Option<String>, // asc|desc
     /// The maximum number of results to return.
@@ -840,7 +852,8 @@ pub async fn get_list(
     }
     let limit_usize = limit as usize;
     // Use checked_add to detect overflow instead of saturating_add
-    let total_span = offset.checked_add(limit_usize)
+    let total_span = offset
+        .checked_add(limit_usize)
         .ok_or_else(|| AppError::BadRequest("offset + limit causes integer overflow".into()))?;
     if total_span > MAX_TOTAL_SPAN {
         return Err(AppError::BadRequest("offset + limit exceeds maximum span".into()));
@@ -920,27 +933,34 @@ pub async fn get_list(
     // With path: list children
     let path = q.path.as_ref().unwrap();
     let pnorm = normalize_query_path(path)?;
-    let dir_rows = sqlx::query(
-        r#"SELECT path, parent_path, depth, logical_size, allocated_size, file_count, dir_count, mtime, atime
-           FROM nodes WHERE scan_id=?1 AND is_dir=1 AND parent_path=?2"#,
-    )
-    .bind(id.to_string())
-    .bind(&pnorm)
-    .fetch_all(&state.db)
-    .await?;
-    let file_rows = sqlx::query(
-        r#"SELECT path, parent_path, logical_size, allocated_size, mtime, atime
-           FROM files WHERE scan_id=?1 AND parent_path=?2"#,
-    )
-    .bind(id.to_string())
-    .bind(&pnorm)
-    .fetch_all(&state.db)
-    .await?;
+    let order_clause = list_order_clause(q.sort.as_deref(), q.order.as_deref());
+    let sql = format!(
+        r#"SELECT kind_rank, path, parent_path, depth, logical_size, allocated_size, file_count, dir_count, mtime, atime
+           FROM (
+               SELECT 0 AS kind_rank, path, parent_path, depth, logical_size, allocated_size, file_count, dir_count, mtime, atime
+               FROM nodes
+               WHERE scan_id=? AND is_dir=1 AND parent_path=?
+               UNION ALL
+               SELECT 1 AS kind_rank, path, parent_path, NULL AS depth, logical_size, allocated_size, NULL AS file_count, NULL AS dir_count, mtime, atime
+               FROM files
+               WHERE scan_id=? AND parent_path=?
+           )
+           {order_clause}
+           LIMIT ? OFFSET ?"#
+    );
+    let rows = sqlx::query(&sql)
+        .bind(id.to_string())
+        .bind(&pnorm)
+        .bind(id.to_string())
+        .bind(&pnorm)
+        .bind(limit)
+        .bind(offset as i64)
+        .fetch_all(&state.db)
+        .await?;
 
-    let mut items: Vec<ListItem> = Vec::with_capacity(dir_rows.len() + file_rows.len());
-    for r in dir_rows {
+    let mut items: Vec<ListItem> = Vec::with_capacity(rows.len());
+    for r in rows {
         let p: String = r.get("path");
-        // FIX Bug #34 - Better error handling for file_name
         let name = std::path::Path::new(&p)
             .file_name()
             .and_then(|s| s.to_str())
@@ -948,43 +968,33 @@ pub async fn get_list(
             .unwrap_or_else(|| p.clone());
         let mtime = r.get::<Option<i64>, _>("mtime");
         let atime = r.get::<Option<i64>, _>("atime");
-        items.push(ListItem::Dir {
-            name,
-            path: p,
-            parent_path: r.get("parent_path"),
-            depth: r.get("depth"),
-            logical_size: r.get("logical_size"),
-            allocated_size: r.get("allocated_size"),
-            file_count: r.get("file_count"),
-            dir_count: r.get("dir_count"),
-            mtime,
-            atime,
-        });
-    }
-    for r in file_rows {
-        let p: String = r.get("path");
-        // FIX Bug #35 - Better error handling for file_name
-        let name = std::path::Path::new(&p)
-            .file_name()
-            .and_then(|s| s.to_str())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| p.clone());
-        let mtime = r.get::<Option<i64>, _>("mtime");
-        let atime = r.get::<Option<i64>, _>("atime");
-        items.push(ListItem::File {
-            name,
-            path: p,
-            parent_path: r.get("parent_path"),
-            logical_size: r.get("logical_size"),
-            allocated_size: r.get("allocated_size"),
-            mtime,
-            atime,
-        });
+        if r.get::<i64, _>("kind_rank") == 0 {
+            items.push(ListItem::Dir {
+                name,
+                path: p,
+                parent_path: r.get("parent_path"),
+                depth: r.get::<Option<i64>, _>("depth").unwrap_or(0),
+                logical_size: r.get("logical_size"),
+                allocated_size: r.get("allocated_size"),
+                file_count: r.get::<Option<i64>, _>("file_count").unwrap_or(0),
+                dir_count: r.get::<Option<i64>, _>("dir_count").unwrap_or(0),
+                mtime,
+                atime,
+            });
+        } else {
+            items.push(ListItem::File {
+                name,
+                path: p,
+                parent_path: r.get("parent_path"),
+                logical_size: r.get("logical_size"),
+                allocated_size: r.get("allocated_size"),
+                mtime,
+                atime,
+            });
+        }
     }
 
-    sort_items(&mut items[..], q.sort.as_deref(), q.order.as_deref());
-    let slice = items.into_iter().skip(offset).take(limit_usize).collect::<Vec<_>>();
-    Ok(Json(slice))
+    Ok(Json(items))
 }
 
 // ---------------------- RECENT ENDPOINT ----------------------
@@ -1021,19 +1031,9 @@ pub async fn get_recent(
 ) -> AppResult<impl IntoResponse> {
     let scope = q.scope.as_deref().unwrap_or("dirs");
     let limit = q.limit.unwrap_or(50).clamp(1, 500);
-    // Fetch a superset to compute atime and then take top-N
-    // Use saturating_mul to prevent overflow, but keep reasonable bounds
-    let fetch_multiplier = std::env::var("SPEICHERWALD_RECENT_FETCH_MULTIPLIER")
-        .ok()
-        .and_then(|v| v.parse::<i64>().ok())
-        .unwrap_or(10)
-        .clamp(5, 20);
-    let fetch_cap = limit.saturating_mul(fetch_multiplier).clamp(100, 2000) as i64;
 
-    // Optional subtree filter: build path range [prefix, prefix + high]
     let mut subtree_eq: Option<String> = None;
-    let mut subtree_lo: Option<String> = None;
-    let mut subtree_hi: Option<String> = None;
+    let mut subtree_like: Option<String> = None;
     if let Some(p) = q.path.as_ref() {
         let peq = normalize_query_path(p)?;
         let mut pfx = peq.clone();
@@ -1044,31 +1044,27 @@ pub async fn get_recent(
                 pfx.push('/');
             }
         }
+        let pfx_escaped = escape_like_pattern(&pfx);
         subtree_eq = Some(peq);
-        subtree_lo = Some(pfx.clone());
-        // Use a high but valid ASCII character instead of Unicode max
-        subtree_hi = Some(format!("{}~", pfx));
+        subtree_like = Some(format!("{}%", pfx_escaped));
     }
 
     let mut items: Vec<TopItem> = Vec::new();
     let want_dirs = scope == "dirs" || scope == "all";
     let want_files = scope == "files" || scope == "all";
 
-    // FIX Bug #2,#8 - Use QueryBuilder instead of string replacement
     if want_dirs {
         let mut qb = QueryBuilder::new(
             "SELECT path, parent_path, depth, logical_size, allocated_size, file_count, dir_count, mtime, atime FROM nodes WHERE scan_id="
         );
         qb.push_bind(id.to_string()).push(" AND is_dir=1");
 
-        if let (Some(eq), Some(lo), Some(hi)) =
-            (subtree_eq.as_ref(), subtree_lo.as_ref(), subtree_hi.as_ref())
-        {
+        if let (Some(eq), Some(like)) = (subtree_eq.as_ref(), subtree_like.as_ref()) {
             qb.push(" AND (path = ").push_bind(eq);
-            qb.push(" OR (path >= ").push_bind(lo);
-            qb.push(" AND path < ").push_bind(hi).push("))");
+            qb.push(" OR path LIKE ").push_bind(like);
+            qb.push(" ESCAPE '!')");
         }
-        qb.push(" LIMIT ").push_bind(fetch_cap);
+        qb.push(" ORDER BY COALESCE(atime, 0) DESC, path ASC LIMIT ").push_bind(limit);
 
         let rows = qb.build().fetch_all(&state.db).await?;
         for r in rows {
@@ -1088,21 +1084,18 @@ pub async fn get_recent(
             });
         }
     }
-    // FIX Bug #3,#9 - Use QueryBuilder instead of string replacement
     if want_files {
         let mut qb = QueryBuilder::new(
             "SELECT path, parent_path, logical_size, allocated_size, mtime, atime FROM files WHERE scan_id=",
         );
         qb.push_bind(id.to_string());
 
-        if let (Some(eq), Some(lo), Some(hi)) =
-            (subtree_eq.as_ref(), subtree_lo.as_ref(), subtree_hi.as_ref())
-        {
+        if let (Some(eq), Some(like)) = (subtree_eq.as_ref(), subtree_like.as_ref()) {
             qb.push(" AND (path = ").push_bind(eq);
-            qb.push(" OR (path >= ").push_bind(lo);
-            qb.push(" AND path < ").push_bind(hi).push("))");
+            qb.push(" OR path LIKE ").push_bind(like);
+            qb.push(" ESCAPE '!')");
         }
-        qb.push(" LIMIT ").push_bind(fetch_cap);
+        qb.push(" ORDER BY COALESCE(atime, 0) DESC, path ASC LIMIT ").push_bind(limit);
 
         let rows = qb.build().fetch_all(&state.db).await?;
         for r in rows {
@@ -1128,6 +1121,36 @@ pub async fn get_recent(
     items.truncate(limit as usize);
 
     Ok(Json(items))
+}
+
+fn list_order_clause(sort: Option<&str>, order: Option<&str>) -> &'static str {
+    let sort_key = match sort {
+        Some("name") | Some("logical") | Some("type") | Some("modified") | Some("accessed")
+        | Some("allocated") => sort.unwrap(),
+        _ => "allocated",
+    };
+
+    let desc = match order {
+        Some("asc") => false,
+        Some("desc") => true,
+        None => matches!(sort_key, "logical" | "allocated" | "modified" | "accessed"),
+        _ => false,
+    };
+
+    match (sort_key, desc) {
+        ("name", false) => "ORDER BY path COLLATE NOCASE ASC, kind_rank ASC, path ASC",
+        ("name", true) => "ORDER BY path COLLATE NOCASE DESC, kind_rank ASC, path DESC",
+        ("logical", false) => "ORDER BY logical_size ASC, path COLLATE NOCASE ASC",
+        ("logical", true) => "ORDER BY logical_size DESC, path COLLATE NOCASE ASC",
+        ("type", false) => "ORDER BY kind_rank ASC, path COLLATE NOCASE ASC",
+        ("type", true) => "ORDER BY kind_rank DESC, path COLLATE NOCASE ASC",
+        ("modified", false) => "ORDER BY COALESCE(mtime, 0) ASC, path COLLATE NOCASE ASC",
+        ("modified", true) => "ORDER BY COALESCE(mtime, 0) DESC, path COLLATE NOCASE ASC",
+        ("accessed", false) => "ORDER BY COALESCE(atime, 0) ASC, path COLLATE NOCASE ASC",
+        ("accessed", true) => "ORDER BY COALESCE(atime, 0) DESC, path COLLATE NOCASE ASC",
+        ("allocated", false) => "ORDER BY allocated_size ASC, path COLLATE NOCASE ASC",
+        _ => "ORDER BY allocated_size DESC, path COLLATE NOCASE ASC",
+    }
 }
 
 fn sort_items(items: &mut [ListItem], sort: Option<&str>, order: Option<&str>) {
@@ -1222,35 +1245,33 @@ fn get_atime(i: &ListItem) -> i64 {
     }
 }
 
-async fn get_subtree_totals(
-    id: Uuid,
-    path: &str,
-    pool: &sqlx::SqlitePool,
-) -> AppResult<(i64, i64)> {
-    let row = sqlx::query(
-        "SELECT file_count, dir_count FROM nodes WHERE scan_id = ?1 AND path = ?2"
-    )
-    .bind(id.to_string())
-    .bind(path)
-    .fetch_optional(pool)
-    .await?;
+async fn get_subtree_totals(id: Uuid, path: &str, pool: &sqlx::SqlitePool) -> AppResult<(i64, i64)> {
+    let row = sqlx::query("SELECT file_count, dir_count FROM nodes WHERE scan_id = ?1 AND path = ?2")
+        .bind(id.to_string())
+        .bind(path)
+        .fetch_optional(pool)
+        .await?;
 
     if let Some(r) = row {
-         Ok((r.get::<i64, _>("file_count"), r.get::<i64, _>("dir_count")))
+        Ok((r.get::<i64, _>("file_count"), r.get::<i64, _>("dir_count")))
     } else {
         Ok((0, 0))
     }
 }
 
 async fn get_mtime_secs(path: &str) -> Option<i64> {
-     tokio::fs::metadata(path).await.ok()
+    tokio::fs::metadata(path)
+        .await
+        .ok()
         .and_then(|m| m.modified().ok())
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_secs() as i64)
 }
 
 async fn get_atime_secs(path: &str) -> Option<i64> {
-     tokio::fs::metadata(path).await.ok()
+    tokio::fs::metadata(path)
+        .await
+        .ok()
         .and_then(|m| m.accessed().ok())
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_secs() as i64)
@@ -1262,8 +1283,7 @@ mod tests {
     use http_body_util::BodyExt;
     use sqlx::sqlite::SqlitePoolOptions;
 
-    #[tokio::test]
-    async fn get_tree_clamps_oversized_limit() {
+    async fn test_state_with_scan() -> (AppState, Uuid) {
         let pool = SqlitePoolOptions::new().max_connections(1).connect("sqlite::memory:").await.unwrap();
         crate::db::init_db(&pool).await.unwrap();
         let state = AppState::new(pool.clone(), crate::config::AppConfig::default());
@@ -1280,6 +1300,13 @@ mod tests {
         .execute(&state.db)
         .await
         .unwrap();
+
+        (state, scan_id)
+    }
+
+    #[tokio::test]
+    async fn get_tree_clamps_oversized_limit() {
+        let (state, scan_id) = test_state_with_scan().await;
 
         for idx in 0..2_100 {
             sqlx::query(
@@ -1310,5 +1337,108 @@ mod tests {
         let items: Vec<NodeDto> = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(items.len(), TREE_LIMIT_MAX as usize);
+    }
+
+    #[tokio::test]
+    async fn get_list_sorts_in_sql_before_paginating() {
+        let (state, scan_id) = test_state_with_scan().await;
+        let parent = r#"C:\root"#.to_string();
+
+        for (path, allocated) in [(r#"C:\root\dir-low"#, 100), (r#"C:\root\dir-high"#, 300)] {
+            sqlx::query(
+                r#"INSERT INTO nodes
+                   (scan_id, path, parent_path, depth, is_dir, logical_size, allocated_size, file_count, dir_count)
+                   VALUES (?1, ?2, ?3, 1, 1, ?4, ?4, 0, 0)"#,
+            )
+            .bind(scan_id.to_string())
+            .bind(path)
+            .bind(Some(parent.clone()))
+            .bind(allocated)
+            .execute(&state.db)
+            .await
+            .unwrap();
+        }
+
+        for (path, allocated) in [(r#"C:\root\file-mid.txt"#, 200), (r#"C:\root\file-top.txt"#, 400)] {
+            sqlx::query(
+                r#"INSERT INTO files
+                   (scan_id, path, parent_path, logical_size, allocated_size)
+                   VALUES (?1, ?2, ?3, ?4, ?4)"#,
+            )
+            .bind(scan_id.to_string())
+            .bind(path)
+            .bind(Some(parent.clone()))
+            .bind(allocated)
+            .execute(&state.db)
+            .await
+            .unwrap();
+        }
+
+        let response = get_list(
+            State(state),
+            Path(scan_id),
+            Query(ListQuery {
+                path: Some(parent),
+                sort: Some("allocated".to_string()),
+                order: Some("desc".to_string()),
+                limit: Some(2),
+                offset: Some(1),
+            }),
+        )
+        .await
+        .unwrap()
+        .into_response();
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let items: Vec<ListItem> = serde_json::from_slice(&body).unwrap();
+        let paths: Vec<String> = items
+            .into_iter()
+            .map(|item| match item {
+                ListItem::Dir { path, .. } | ListItem::File { path, .. } => path,
+            })
+            .collect();
+
+        assert_eq!(paths, vec![r#"C:\root\dir-high"#, r#"C:\root\file-mid.txt"#]);
+    }
+
+    #[tokio::test]
+    async fn get_recent_orders_before_limiting() {
+        let (state, scan_id) = test_state_with_scan().await;
+        let parent = r#"C:\root"#.to_string();
+
+        for idx in 0..120 {
+            sqlx::query(
+                r#"INSERT INTO files
+                   (scan_id, path, parent_path, logical_size, allocated_size, atime)
+                   VALUES (?1, ?2, ?3, 1, 1, ?4)"#,
+            )
+            .bind(scan_id.to_string())
+            .bind(format!(r#"C:\root\file-{idx:03}.txt"#))
+            .bind(Some(parent.clone()))
+            .bind(idx as i64)
+            .execute(&state.db)
+            .await
+            .unwrap();
+        }
+
+        let response = get_recent(
+            State(state),
+            Path(scan_id),
+            Query(RecentQuery { scope: Some("files".to_string()), limit: Some(1), path: Some(parent) }),
+        )
+        .await
+        .unwrap()
+        .into_response();
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let items: Vec<TopItem> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            TopItem::File { path, atime, .. } => {
+                assert_eq!(path, r#"C:\root\file-119.txt"#);
+                assert_eq!(*atime, Some(119));
+            }
+            other => panic!("expected a file, got {other:?}"),
+        }
     }
 }

--- a/src/routes/search.rs
+++ b/src/routes/search.rs
@@ -194,7 +194,6 @@ fn sanitize_search_term(raw: &str) -> Result<String, AppError> {
     Ok(sanitized)
 }
 
-
 /// Searches for files and directories within a scan.
 ///
 /// This endpoint supports full-text search, size filtering, and type filtering.
@@ -236,7 +235,7 @@ pub async fn search_scan(
     // We'll execute a single UNION query with global ORDER+LIMIT+OFFSET.
     // Clamp to keep resource usage bounded even with large offsets. (FIX Bug #19)
     let limit_clamped = query.limit.clamp(1, 1000);
-    let offset_clamped = query.offset.max(0).min(10_000); // Prevent excessive offset and performance issues
+    let offset_clamped = query.offset.clamp(0, 10_000); // Prevent excessive offset and performance issues
 
     // Validate that offset + limit doesn't overflow
     if let Some(_overflow) = offset_clamped.checked_add(limit_clamped) {
@@ -370,10 +369,8 @@ pub async fn search_scan(
             });
         } else {
             // Extract file extension properly with better validation (FIX Bug #4)
-            let extension = std::path::Path::new(&path)
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .and_then(|ext| {
+            let extension =
+                std::path::Path::new(&path).extension().and_then(|ext| ext.to_str()).and_then(|ext| {
                     // Validate extension:
                     // 1. Not empty
                     // 2. No path separators in extension (Path::extension handles this mostly, but good to double check)

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -150,7 +150,10 @@ pub async fn run_scan(
     let channel_size = match concurrency.checked_mul(8).and_then(|v| v.checked_add(128)) {
         Some(size) => size.clamp(256, 2048),
         None => {
-            tracing::warn!("Channel size calculation overflow for concurrency={}, using default 2048", concurrency);
+            tracing::warn!(
+                "Channel size calculation overflow for concurrency={}, using default 2048",
+                concurrency
+            );
             2048
         }
     };
@@ -325,7 +328,6 @@ pub async fn run_scan(
                                 if tx_res_cl.is_closed() {
                                     return; // Stop processing if receiver is gone (Zombie prevention)
                                 }
-
                             }
                         }
                     }
@@ -353,7 +355,7 @@ pub async fn run_scan(
             let mut running: Vec<std::thread::JoinHandle<ScanResultSummary>> = Vec::new();
             let sub_count = subdirs.len();
             // Cap dir_limit to prevent resource exhaustion
-            let dir_limit = dir_conc.max(1).min(64);
+            let dir_limit = dir_conc.clamp(1, 64);
             let mut sub_dirs_total: u64 = 0;
             let mut sub_files_total: u64 = 0;
             let mut subtree_logical: u64 = 0;
@@ -393,10 +395,16 @@ pub async fn run_scan(
                             let _ = tx_res_sub.blocking_send((snodes, sfiles, delta));
                             ssum
                         }));
-                        result.unwrap_or_else(|_| {
-                            tracing::error!("Thread panicked during scan");
-                            ScanResultSummary::default()
-                        })
+                        match result {
+                            Ok(summary) => summary,
+                            Err(_) => {
+                                tracing::error!("Thread panicked during scan");
+                                let warn_summary = ScanResultSummary { warnings: 1, ..Default::default() };
+                                let _ =
+                                    tx_res_sub.blocking_send((Vec::new(), Vec::new(), warn_summary.clone()));
+                                warn_summary
+                            }
+                        }
                     });
                     running.push(handle);
                 }
@@ -415,12 +423,8 @@ pub async fn run_scan(
                             Err(e) => {
                                 tracing::error!("Worker thread panicked: {:?}", e);
                                 // FIX Bug #3: Track panic as warning to avoid silent data loss
-                                let mut warn_summary = ScanResultSummary { warnings: 1, ..Default::default() };
-                                // accumulate into root aggregates
-                                subtree_logical = subtree_logical.saturating_add(warn_summary.total_logical_size);
-                                subtree_alloc = subtree_alloc.saturating_add(warn_summary.total_allocated_size);
-                                sub_dirs_total = sub_dirs_total.saturating_add(warn_summary.total_dirs);
-                                sub_files_total = sub_files_total.saturating_add(warn_summary.total_files);
+                                let warn_summary = ScanResultSummary { warnings: 1, ..Default::default() };
+                                let _ = tx_res_cl.blocking_send((Vec::new(), Vec::new(), warn_summary));
                             }
                         }
                     }
@@ -640,6 +644,7 @@ fn scan_dir(
                             continue; // Don't recurse deeper
                         }
                     }
+                    let mut child_summary = ScanResultSummary::default();
                     let (d_dirs, d_files, d_logical, d_alloc) = scan_dir(
                         _scan_id,
                         &path,
@@ -648,12 +653,15 @@ fn scan_dir(
                         globset,
                         tx,
                         cancel,
-                        summary,
+                        &mut child_summary,
                         nodes,
                         files,
                         tx_out,
                         flush_threshold,
                     )?;
+                    summary.warnings = summary.warnings.saturating_add(child_summary.warnings);
+                    summary.latest_mtime = max_opt(summary.latest_mtime, child_summary.latest_mtime);
+                    summary.latest_atime = max_opt(summary.latest_atime, child_summary.latest_atime);
                     local_dirs += d_dirs;
                     local_files += d_files;
                     logical = logical.saturating_add(d_logical);
@@ -689,7 +697,7 @@ fn scan_dir(
                 sent = sent.saturating_add(1);
                 // Reduzierte Progress-Updates für bessere Performance
                 // FIX Bug #13: Remove redundant sent > 0 check (modulo handles zero)
-                if sent % 512 == 0 {
+                if sent.is_multiple_of(512) {
                     let _ = tx.send(ScanEvent::Progress {
                         current_path: path.to_string_lossy().to_string(),
                         dirs_scanned: summary.total_dirs + local_dirs,
@@ -804,7 +812,7 @@ fn matches_excludes(path: &Path, set: &GlobSet) -> bool {
     if s.contains('\u{FFFD}') {
         // FIX Bug #9: Allow invalid UTF-8 paths (they are lossy converted but should still be scanned)
         // tracing::warn!("Path contains invalid UTF-8: {:?}", path);
-        // return true; 
+        // return true;
     }
     let normalized = s.replace('\\', "/");
     if set.is_match(&normalized) {
@@ -817,7 +825,6 @@ fn matches_excludes(path: &Path, set: &GlobSet) -> bool {
         }
     }
     false
-
 }
 
 #[cfg(windows)]
@@ -888,10 +895,7 @@ fn is_hidden_or_system(_path: &Path, md: &fs::Metadata) -> bool {
 #[cfg(not(windows))]
 fn is_hidden_or_system(path: &Path, _md: &fs::Metadata) -> bool {
     // Check for dotfiles on Unix
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .map(|s| s.starts_with('.'))
-        .unwrap_or(false)
+    path.file_name().and_then(|n| n.to_str()).map(|s| s.starts_with('.')).unwrap_or(false)
 }
 
 #[cfg(windows)]
@@ -1012,7 +1016,7 @@ async fn persist_batches(
         return Ok(());
     }
     let sid = id.to_string();
-    
+
     // Respect SQLite variable limit
     const SQLITE_MAX_VARS: usize = 999;
     const NODE_BINDS_PER_ROW: usize = 11;
@@ -1025,7 +1029,7 @@ async fn persist_batches(
     // chunk sizes for query construction
     let node_chunk_size = batch_size.max(1).min(max_node_rows_per_stmt.max(1));
     let file_chunk_size = batch_size.max(1).min(max_file_rows_per_stmt.max(1));
-    
+
     // FIX Bug #6: Commit intermediate transactions to avoid huge internal journals and locks
     let mut txdb = pool.begin().await?;
     let mut chunks_processed = 0;
@@ -1055,7 +1059,7 @@ async fn persist_batches(
                 .push_bind(n.atime);
         });
         qb.build().execute(&mut *txdb).await?;
-        
+
         chunks_processed += 1;
         if chunks_processed >= 5 {
             txdb.commit().await?;
@@ -1083,7 +1087,7 @@ async fn persist_batches(
                 .push_bind(f.atime);
         });
         qb.build().execute(&mut *txdb).await?;
-        
+
         chunks_processed += 1;
         if chunks_processed >= 5 {
             txdb.commit().await?;

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -835,12 +835,6 @@ fn is_unc_path(path: &Path) -> bool {
     s.starts_with("\\\\?\\UNC\\") || s.starts_with("\\\\")
 }
 
-#[cfg(not(windows))]
-#[inline]
-fn is_unc_path(_path: &Path) -> bool {
-    false
-}
-
 #[cfg(windows)]
 #[inline]
 fn is_network_path(path: &Path) -> bool {
@@ -910,10 +904,13 @@ fn is_reparse_point(_md: &fs::Metadata) -> bool {
 }
 
 // Cache für häufig abgefragte Pfade
+#[cfg(windows)]
 use lru::LruCache;
+#[cfg(windows)]
 use std::sync::Mutex;
 
 // Configurable cache size via environment variable, default 10000
+#[cfg(windows)]
 fn get_cache_size() -> usize {
     std::env::var("SPEICHERWALD_SIZE_CACHE_ENTRIES")
         .ok()
@@ -922,6 +919,7 @@ fn get_cache_size() -> usize {
         .clamp(100, 100_000)
 }
 
+#[cfg(windows)]
 lazy_static::lazy_static! {
     static ref SIZE_CACHE: Mutex<LruCache<PathBuf, Option<u64>>> = {
         let size = get_cache_size();

--- a/src/state.rs
+++ b/src/state.rs
@@ -17,7 +17,7 @@ use crate::types::ScanEvent;
 #[derive(Clone)]
 pub struct JobHandle {
     /// A cancellation token for stopping the job.
-    /// 
+    ///
     /// When this token is cancelled, the scan job should gracefully terminate
     /// its operations and clean up any resources.
     pub cancel: CancellationToken,

--- a/src/tests/scanner_tests.rs
+++ b/src/tests/scanner_tests.rs
@@ -57,11 +57,21 @@ mod tests {
             follow_symlinks: false,
             include_hidden: true,
             measure_logical: true,
-            measure_allocated: true,
+            measure_allocated: false,
             excludes: vec![],
             max_depth: None,
             concurrency: Some(4),
         };
+        let expected_files = [
+            temp_dir.path().join("file1.txt"),
+            temp_dir.path().join("dir1/file2.txt"),
+            temp_dir.path().join("dir1/subdir1/file3.txt"),
+            temp_dir.path().join(".hidden/secret.txt"),
+        ];
+        let expected_logical_size: u64 = expected_files
+            .iter()
+            .map(|path| fs::metadata(path).unwrap().len())
+            .sum();
 
         let summary = run_scan(
             pool.clone(),
@@ -79,8 +89,10 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(summary.total_files > 0);
-        assert!(summary.total_dirs > 0);
+        assert_eq!(summary.total_files, 4);
+        assert_eq!(summary.total_dirs, 6);
+        assert_eq!(summary.total_logical_size, expected_logical_size);
+        assert_eq!(summary.total_allocated_size, expected_logical_size);
 
         let nodes_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM nodes WHERE scan_id=?1")
             .bind(id.to_string())
@@ -92,8 +104,16 @@ mod tests {
             .fetch_one(&pool)
             .await
             .unwrap();
-        assert!(nodes_count > 0);
-        assert!(files_count >= 0);
+        let stored_logical_size: i64 =
+            sqlx::query_scalar("SELECT COALESCE(SUM(logical_size), 0) FROM files WHERE scan_id=?1")
+                .bind(id.to_string())
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        assert_eq!(nodes_count, summary.total_dirs as i64);
+        assert_eq!(files_count, summary.total_files as i64);
+        assert_eq!(stored_logical_size, summary.total_logical_size as i64);
     }
 
     #[tokio::test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -47,6 +47,7 @@ pub struct NodeDto {
 
 /// A data transfer object for a file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct FileDto {
     /// The path of the file.
     pub path: String,
@@ -203,7 +204,7 @@ impl Default for ScanOptions {
     fn default() -> Self {
         // Calculate concurrency: use half the CPU cores, minimum 2, maximum 16
         let cpu_count = num_cpus::get();
-        let default_concurrency = (cpu_count / 2).max(2).min(16);
+        let default_concurrency = (cpu_count / 2).clamp(2, 16);
 
         Self {
             follow_symlinks: false,

--- a/webui/src/api.rs
+++ b/webui/src/api.rs
@@ -339,6 +339,7 @@ pub async fn get_list(id: &str, q: &ListQuery) -> Result<Vec<ListItem>, String> 
 /// Provides comprehensive search capabilities including text matching,
 /// size filtering, file type filtering, and result limiting.
 #[derive(Debug, Clone, Default, Serialize)]
+#[allow(dead_code)]
 pub struct SearchQuery {
     /// Search query string for matching file/directory names
     pub query: String,
@@ -381,6 +382,7 @@ pub struct SearchQuery {
 /// - Use `include_files` and `include_dirs` to control result types
 /// - Results can be paginated using `limit` and `offset` parameters
 /// - Search is case-insensitive for text matching
+#[allow(dead_code)]
 pub async fn search_scan(id: &str, q: &SearchQuery) -> Result<SearchResult, String> {
     let mut qs = vec![];
     qs.push(format!("query={}", urlencoding::encode(&q.query)));

--- a/webui/src/main.rs
+++ b/webui/src/main.rs
@@ -20,6 +20,8 @@
 //! - **Real-time**: SSE for live scan progress monitoring
 //! - **Error Handling**: User-friendly error messages and fallbacks
 
+#![allow(clippy::clone_on_copy, clippy::redundant_closure)]
+
 use dioxus::events::FormData;
 use dioxus::prelude::*;
 
@@ -463,10 +465,6 @@ fn Scan(id: String) -> Element {
             }
         });
     }
-
-    // Export-Steuerung
-    let export_scope = use_signal(|| "all".to_string()); // all|nodes|files
-    let export_limit = use_signal(|| 10000_i64);
 
     // Live-Update & Throttle
     let last_refresh = use_signal(|| 0.0_f64);
@@ -1546,7 +1544,9 @@ fn Scan(id: String) -> Element {
                                             }
                                         } else {
                                             show_toast("Keine vorherige Seite");
-                                            console::log_1(&format!("Prev click on page 1 (offset=0). No nav history. path=None").into());
+                                            console::log_1(
+                                                &"Prev click on page 1 (offset=0). No nav history. path=None".into(),
+                                            );
                                         }
                                     } else {
                                         // Remove current entry
@@ -2425,8 +2425,8 @@ fn Scan(id: String) -> Element {
                         // FIX Bug #16: Add bounds check for float to usize cast
                         if max_alloc_bar > 0 { 
                             let calc = ((alloc as f64) / (max_alloc_bar as f64) * 40.0).round();
-                            blocks = if calc >= 0.0 && calc <= 1000.0 {
-                                (calc as usize).max(1).min(1000)
+                            blocks = if (0.0..=1000.0).contains(&calc) {
+                                (calc as usize).clamp(1, 1000)
                             } else {
                                 1
                             };
@@ -2702,7 +2702,7 @@ fn move_dialog_view(
                                     if stripped_source.len() >= 3 && stripped_source.chars().nth(1) == Some(':') && (stripped_source.chars().nth(2) == Some('\\') || stripped_source.chars().nth(2) == Some('/')) {
                                         stripped_source = &stripped_source[3..];
                                     } else if stripped_source.starts_with("\\\\") || stripped_source.starts_with("//") {
-                                        let mut parts = stripped_source[2..].splitn(3, |c| c == '\\' || c == '/');
+                                        let mut parts = stripped_source[2..].splitn(3, ['\\', '/']);
                                         parts.next();
                                         parts.next();
                                         if let Some(rest) = parts.next() { stripped_source = rest; } else { stripped_source = ""; }
@@ -2923,7 +2923,7 @@ fn move_dialog_view(
                                             if stripped.len() >= 3 && stripped.chars().nth(1) == Some(':') && (stripped.chars().nth(2) == Some('\\') || stripped.chars().nth(2) == Some('/')) {
                                                 stripped = &stripped[3..];
                                             } else if stripped.starts_with("\\\\") || stripped.starts_with("//") {
-                                                let mut parts = stripped[2..].splitn(3, |c| c == '\\' || c == '/');
+                                                let mut parts = stripped[2..].splitn(3, ['\\', '/']);
                                                 parts.next(); parts.next();
                                                 if let Some(rest) = parts.next() { stripped = rest; } else { stripped = ""; }
                                             } else if stripped.starts_with('/') || stripped.starts_with('\\') {
@@ -3027,16 +3027,8 @@ fn move_dialog_view(
 }
 
 // ----- Styles & Helfer -----
-fn panel_style() -> &'static str {
-    "max-width:1200px;margin:20px auto;padding:16px;background:#0b0c10;color:#e5e7eb;border:1px solid #222533;border-radius:12px;"
-}
-
 fn btn_style() -> &'static str {
     "background:#1f2937;color:#e5e7eb;border:1px solid #374151;border-radius:8px;padding:6px 10px;cursor:pointer;"
-}
-
-fn btn_danger_style() -> &'static str {
-    "background:#7f1d1d;color:#fff;border:1px solid #991b1b;border-radius:8px;padding:6px 10px;cursor:pointer;"
 }
 
 fn btn_primary_style() -> &'static str {

--- a/webui/src/types.rs
+++ b/webui/src/types.rs
@@ -111,6 +111,7 @@ pub enum ListItem {
 /// Contains the items matching a search query along with metadata
 /// about the search itself, including total count and query string.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[allow(dead_code)]
 pub struct SearchResult {
     pub items: Vec<SearchItem>,
     pub total_count: i64,
@@ -122,6 +123,7 @@ pub struct SearchResult {
 /// Represents a file or directory that was found during a search operation,
 /// with relevant metadata for display and selection.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[allow(dead_code)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SearchItem {
     Dir {

--- a/webui/src/ui_utils.rs
+++ b/webui/src/ui_utils.rs
@@ -144,8 +144,6 @@ pub fn fmt_ago_short(ts: Option<i64>) -> String {
     }
 }
 
-/// (removed duplicate trigger_download)
-
 /// Copies text to the user's clipboard and shows a toast notification.
 ///
 /// Attempts to copy the provided text to the system clipboard and displays
@@ -240,6 +238,7 @@ pub fn show_toast(message: &str) {
 /// - Uses browser's local timezone for formatting
 /// - Maximum valid timestamp is year 9999 for overflow protection
 /// - Gracefully falls back for date conversion errors
+#[allow(dead_code)]
 pub fn fmt_time_opt(ts: Option<i64>) -> String {
     match ts {
         Some(secs) => {


### PR DESCRIPTION
## Summary

- Fix scanner aggregate accounting so nested subtree totals are not double-counted, with regression coverage for exact file, directory, and size totals.
- Move large-directory list and recent-file queries to SQL-side ordering and pagination to avoid loading broad result sets into memory before slicing.
- Harden scan cancellation/purge and move fallback behavior, including delayed cleanup for running jobs, disk-space checks before fallback copies, and surfaced delete warnings.
- Add backend and WebUI Clippy warning gates to CI and clean the current backend, WebUI, and desktop warning surface.

## Why

The review found correctness and scalability risks in scan totals, directory listing, recent-file selection, purge timing, and move fallback handling. This PR keeps the fixes focused on those issues and turns the warning-clean expectation into a CI-enforced contract.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test --manifest-path webui/Cargo.toml`
- `cargo clippy --manifest-path webui/Cargo.toml --all-targets -- -D warnings`
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

Note: `cargo fmt` completed successfully; it still prints the existing warnings about nightly-only rustfmt options.